### PR TITLE
Model multi-session invoices, switch tariffs to price-per-kWh + parking, and add BDD edge/validation coverage

### DIFF
--- a/src/main/java/org/example/ChargingSessionManager.java
+++ b/src/main/java/org/example/ChargingSessionManager.java
@@ -62,9 +62,9 @@ public class ChargingSessionManager {
      * - endTime (e.g. new Date() for "now")
      * - charging point type (AC/DC) to pick the right tariff values
      *
-     * IMPORTANT: This matches your NEW meaning of tariff:
-     *   tariff.pricePerKwhAC/DC = "kW speed" (power)
-     *   tariff.pricePerMinuteAC/DC = "price per minute"
+     * IMPORTANT: Tariff meaning:
+     *   tariff.pricePerKwhAC/DC = price per kWh
+     *   tariff.pricePerMinuteAC/DC = parking price per minute
      */
     public Calculation calculateForSession(
             ChargingSession session,
@@ -84,15 +84,14 @@ public class ChargingSessionManager {
         long minutes = (endTime.getTime() - session.startTime().getTime()) / 60000;
         if (minutes < 0) minutes = 0;
 
-        // tariff fields interpreted as:
-        // powerKw = pricePerKwhAC/DC
-        // pricePerMin = pricePerMinuteAC/DC
-        double powerKw = (type == ChargingType.AC) ? tariff.pricePerKwhAC() : tariff.pricePerKwhDC();
+        double pricePerKwh = (type == ChargingType.AC) ? tariff.pricePerKwhAC() : tariff.pricePerKwhDC();
         double pricePerMin = (type == ChargingType.AC) ? tariff.pricePerMinuteAC() : tariff.pricePerMinuteDC();
+
+        double powerKw = (type == ChargingType.AC) ? 11.0 : 50.0;
 
         double hours = minutes / 60.0;
         double kWh = powerKw * hours;
-        double cost = minutes * pricePerMin;
+        double cost = (kWh * pricePerKwh) + (minutes * pricePerMin);
 
         return new Calculation(minutes, kWh, cost);
     }

--- a/src/main/java/org/example/CustomerManager.java
+++ b/src/main/java/org/example/CustomerManager.java
@@ -9,6 +9,12 @@ public class CustomerManager {
 
     // SYSTEM generates the ID
     public Customer createCustomer(String firstName, String lastName) {
+        if (firstName == null || firstName.isBlank()) {
+            throw new IllegalArgumentException("first name must not be empty");
+        }
+        if (lastName == null || lastName.isBlank()) {
+            throw new IllegalArgumentException("last name must not be empty");
+        }
         String id = "C" + nextId++;
         Customer customer = new Customer(id, firstName, lastName);
         customers.put(id, customer);

--- a/src/main/java/org/example/ElectricChargingPointNetwork.java
+++ b/src/main/java/org/example/ElectricChargingPointNetwork.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Scanner;
 
@@ -46,15 +47,16 @@ public class ElectricChargingPointNetwork {
         locationManager.createLocation("L13", "Krems Altstadt", "Obere Landstrasse 22");
 
 
-        locationManager.defineTariff("L1", 20, 15, 0.09, 0.01);        locationManager.defineTariff("L2", 11, 50, 0.06, 0.25);   // City AC slow / DC fast
-        locationManager.defineTariff("L3", 22, 75, 0.08, 0.30);   // Shopping center
-        locationManager.defineTariff("L4", 11, 100, 0.07, 0.35);  // Highway charger
-        locationManager.defineTariff("L5", 22, 150, 0.09, 0.45);  // Fast DC hub
-        locationManager.defineTariff("L6", 7.4, 50, 0.05, 0.22);  // Residential area
-        locationManager.defineTariff("L7", 11, 75, 0.06, 0.28);   // Office parking
-        locationManager.defineTariff("L8", 22, 120, 0.08, 0.40);  // Premium location
-        locationManager.defineTariff("L9", 11, 60, 0.06, 0.26);   // Regional charger
-        locationManager.defineTariff("L10", 22, 180, 0.10, 0.55); // Ultra-fast DC
+        locationManager.defineTariff("L1", 0.20, 0.15, 0.09, 0.01);
+        locationManager.defineTariff("L2", 0.11, 0.50, 0.06, 0.25);
+        locationManager.defineTariff("L3", 0.22, 0.75, 0.08, 0.30);
+        locationManager.defineTariff("L4", 0.11, 1.00, 0.07, 0.35);
+        locationManager.defineTariff("L5", 0.22, 1.50, 0.09, 0.45);
+        locationManager.defineTariff("L6", 0.07, 0.50, 0.05, 0.22);
+        locationManager.defineTariff("L7", 0.11, 0.75, 0.06, 0.28);
+        locationManager.defineTariff("L8", 0.22, 1.20, 0.08, 0.40);
+        locationManager.defineTariff("L9", 0.11, 0.60, 0.06, 0.26);
+        locationManager.defineTariff("L10", 0.22, 1.80, 0.10, 0.55);
 
 
         chargingPointManager.createChargingPoint("CP1", "L1", ChargingType.AC, ChargingPointStatus.AVAILABLE);
@@ -102,7 +104,7 @@ public class ElectricChargingPointNetwork {
         invoiceManager.addTopUp("T1", c1.id(), 20.00, parseIsoDateTime("2026-01-17T09:00"));
         invoiceManager.addTopUp("T2", c1.id(), 15.00, parseIsoDateTime("2026-01-17T09:30"));
         ChargingSession s1 = chargingSessionManager.readSession("S1");
-        invoiceManager.addInvoice("I1", c1.id(), s1, parseIsoDateTime("2026-01-17T10:30"), InvoiceStatus.PAID);
+        invoiceManager.addInvoice("I1", c1.id(), List.of(s1), parseIsoDateTime("2026-01-17T10:30"), InvoiceStatus.PAID);
 
         Scanner scanner = new Scanner(System.in);
 
@@ -157,8 +159,8 @@ public class ElectricChargingPointNetwork {
                 
                 create location <id> <name_with_underscores> <address_with_underscores>
                 create charging point <id> <locationId> <AC|DC> <AVAILABLE|OCCUPIED|OUT_OF_ORDER>
-                define tariff <locationId> <kWhAC> <kWhDC> <minAC> <minDC>
-                update tariff <locationId> <kWhAC> <kWhDC> <minAC> <minDC>
+                define tariff <locationId> <kWhAC> <kWhDC> <parkingMinAC> <parkingMinDC>
+                update tariff <locationId> <kWhAC> <kWhDC> <parkingMinAC> <parkingMinDC>
                 back
                 """);
 
@@ -235,8 +237,16 @@ public class ElectricChargingPointNetwork {
 
                 System.out.println("\nInvoices:");
                 var invoices = invoiceManager.readInvoices(customerId);
-                if (invoices.isEmpty()) System.out.println("  (none)");
-                else invoices.forEach(inv -> System.out.println("  " + inv));
+                if (invoices.isEmpty()) {
+                    System.out.println("  (none)");
+                } else {
+                    for (Invoice inv : invoices) {
+                        System.out.println("  " + inv);
+                        for (ChargingSession session : inv.sessions()) {
+                            System.out.println("    " + session);
+                        }
+                    }
+                }
 
                 System.out.println("\nBalance: " + money(invoiceManager.readBalance(customerId)));
                 continue;
@@ -486,46 +496,84 @@ public class ElectricChargingPointNetwork {
                 if (invoices.isEmpty()) {
                     System.out.println("(no invoices)");
                 } else {
-
-                    // sort by session start time
-                    invoices.sort(java.util.Comparator.comparing(i -> i.session().startTime()));
-
+                    invoices.sort(java.util.Comparator.comparing(inv -> inv.sessions().stream()
+                            .map(ChargingSession::startTime)
+                            .filter(java.util.Objects::nonNull)
+                            .min(Date::compareTo)
+                            .orElse(new Date(0))));
                     int itemNo = 1;
                     for (Invoice inv : invoices) {
-
-                        ChargingSession s = inv.session();
-                        ChargingPoint cp = chargingPointManager.readChargingPoint(s.chargingPointId());
-
-                        String locationName = "UNKNOWN";
-                        String mode = "UNKNOWN";
-
-                        if (cp != null) {
-                            mode = cp.type().name(); // AC / DC
-                            Location loc = locationManager.readLocation(cp.locationId());
-                            if (loc != null) {
-                                locationName = loc.name();
-                            }
-                        }
-
-                        long durationMin = 0;
-                        if (s.startTime() != null && s.endTime() != null) {
-                            durationMin = (s.endTime().getTime() - s.startTime().getTime()) / 60000;
-                        }
+                        List<ChargingSession> sessions = new java.util.ArrayList<>(inv.sessions());
+                        sessions.sort(java.util.Comparator.comparing(ChargingSession::startTime));
 
                         System.out.printf(
                                 Locale.ROOT,
-                                "%d) invoice=%s | location=%s | cp=%s | mode=%s | duration=%d min | energy=%.2f kWh | price=%.2f | status=%s%n",
+                                "%d) invoice=%s | total=%.2f | status=%s%n",
                                 itemNo++,
                                 inv.id(),
-                                locationName,
-                                s.chargingPointId(),
-                                mode,
-                                durationMin,
-                                s.kWhCharged(),
-                                s.totalCost(),
+                                inv.totalCost(),
                                 inv.status()
                         );
+
+                        int lineNo = 1;
+                        for (ChargingSession s : sessions) {
+                            ChargingPoint cp = chargingPointManager.readChargingPoint(s.chargingPointId());
+
+                            String locationName = "UNKNOWN";
+                            String mode = "UNKNOWN";
+                            Tariff tariff = null;
+
+                            if (cp != null) {
+                                mode = cp.type().name();
+                                Location loc = locationManager.readLocation(cp.locationId());
+                                if (loc != null) {
+                                    locationName = loc.name();
+                                    tariff = loc.tariff();
+                                }
+                            }
+
+                            long durationMin = 0;
+                            if (s.startTime() != null && s.endTime() != null) {
+                                durationMin = (s.endTime().getTime() - s.startTime().getTime()) / 60000;
+                            }
+
+                            double pricePerKwh = 0.0;
+                            double parkingPerMin = 0.0;
+                            if (tariff != null && cp != null) {
+                                pricePerKwh = (cp.type() == ChargingType.AC) ? tariff.pricePerKwhAC() : tariff.pricePerKwhDC();
+                                parkingPerMin = (cp.type() == ChargingType.AC) ? tariff.pricePerMinuteAC() : tariff.pricePerMinuteDC();
+                            }
+
+                            double energyCost = s.kWhCharged() * pricePerKwh;
+                            double parkingCost = durationMin * parkingPerMin;
+
+                            System.out.printf(
+                                    Locale.ROOT,
+                                    "  %d.%d) %s | cp=%s | mode=%s | duration=%d min | energy=%.2f kWh @ %.2f | energyCost=%.2f | parkingCost=%.2f | total=%.2f%n",
+                                    itemNo - 1,
+                                    lineNo++,
+                                    locationName,
+                                    s.chargingPointId(),
+                                    mode,
+                                    durationMin,
+                                    s.kWhCharged(),
+                                    pricePerKwh,
+                                    energyCost,
+                                    parkingCost,
+                                    s.totalCost()
+                            );
+                        }
                     }
+                }
+
+                System.out.println("Top-ups (sorted by time):");
+                var topUps = invoiceManager.readTopUps(loggedInCustomer.id());
+                if (topUps.isEmpty()) {
+                    System.out.println("(no top-ups)");
+                } else {
+                    topUps.stream()
+                            .sorted(java.util.Comparator.comparing(TopUp::dateTime))
+                            .forEach(t -> System.out.println("  " + t));
                 }
 
                 System.out.println("Current balance: " + money(invoiceManager.readBalance(loggedInCustomer.id())));
@@ -594,22 +642,24 @@ public class ElectricChargingPointNetwork {
                 // If ACTIVE -> show live values (duration + estimated kWh + estimated cost)
                 if (s.status() == ChargingSessionStatus.ACTIVE) {
                     ChargingPoint cp = chargingPointManager.readChargingPoint(s.chargingPointId());
+                    if (cp == null) {
+                        System.out.println("Live: charging point missing.");
+                        continue;
+                    }
+
                     Location loc = locationManager.readLocation(cp.locationId());
+                    if (loc == null || loc.tariff() == null) {
+                        System.out.println("Live: tariff missing.");
+                        continue;
+                    }
 
-                    long minutes = (new Date().getTime() - s.startTime().getTime()) / 60000;
-
-                    double kw = (cp.type() == ChargingType.AC) ? 11.0 : 50.0; // FIXED POWER
-                    double hours = minutes / 60.0;
-                    double kWh = kw * hours;
-
-                    Tariff t = loc.tariff();
-                    double cost = kWh * (cp.type() == ChargingType.AC ? t.pricePerKwhAC() : t.pricePerKwhDC())
-                            + minutes * (cp.type() == ChargingType.AC ? t.pricePerMinuteAC() : t.pricePerMinuteDC());
+                    ChargingSessionManager.Calculation calc =
+                            chargingSessionManager.calculateForSession(s, new Date(), cp.type(), loc.tariff());
 
                     System.out.println("Live:");
-                    System.out.println("  durationMin=" + minutes);
-                    System.out.println("  estKWh=" + String.format(Locale.ROOT, "%.2f", kWh));
-                    System.out.println("  estCost=" + String.format(Locale.ROOT, "%.2f", cost));
+                    System.out.println("  durationMin=" + calc.durationMinutes());
+                    System.out.println("  estKWh=" + String.format(Locale.ROOT, "%.2f", calc.kWhCharged()));
+                    System.out.println("  estCost=" + String.format(Locale.ROOT, "%.2f", calc.totalCost()));
                 }
                 continue;
             }

--- a/src/main/java/org/example/Invoice.java
+++ b/src/main/java/org/example/Invoice.java
@@ -1,17 +1,24 @@
 package org.example;
 
 import java.util.Date;
+import java.util.List;
 
 public record Invoice(
         String id,
         String customerId,
-        ChargingSession session,
+        List<ChargingSession> sessions,
         Date createdAt,
         InvoiceStatus status
 ) {
+    public double totalCost() {
+        return sessions.stream()
+                .mapToDouble(ChargingSession::totalCost)
+                .sum();
+    }
+
     @Override
     public String toString() {
-        return "Invoice{id='%s', customerId='%s', sessionId='%s', totalCost=%.2f, status=%s}"
-                .formatted(id, customerId, session.id(), session.totalCost(), status);
+        return "Invoice{id='%s', customerId='%s', sessions=%d, totalCost=%.2f, status=%s}"
+                .formatted(id, customerId, sessions.size(), totalCost(), status);
     }
 }

--- a/src/main/java/org/example/InvoiceManager.java
+++ b/src/main/java/org/example/InvoiceManager.java
@@ -30,14 +30,23 @@ public class InvoiceManager {
 
     // ✅ unchanged (still supported if you want to pass an ID manually)
     public void addInvoice(String invoiceId, String customerId, ChargingSession session, Date createdAt, InvoiceStatus status) {
+        addInvoice(invoiceId, customerId, List.of(session), createdAt, status);
+    }
+
+    public void addInvoice(String invoiceId, String customerId, List<ChargingSession> sessions, Date createdAt, InvoiceStatus status) {
         if (invoiceId == null || invoiceId.isBlank()) {
             throw new IllegalArgumentException("invoiceId must not be empty");
         }
         if (customerId == null || customerId.isBlank()) {
             throw new IllegalArgumentException("customerId must not be empty");
         }
-        if (session == null) {
-            throw new IllegalArgumentException("session must not be null");
+        if (sessions == null || sessions.isEmpty()) {
+            throw new IllegalArgumentException("sessions must not be empty");
+        }
+        for (ChargingSession session : sessions) {
+            if (session == null) {
+                throw new IllegalArgumentException("session must not be null");
+            }
         }
         if (createdAt == null) {
             throw new IllegalArgumentException("createdAt must not be null");
@@ -46,7 +55,7 @@ public class InvoiceManager {
             throw new IllegalArgumentException("status must not be null");
         }
 
-        Invoice invoice = new Invoice(invoiceId, customerId, session, createdAt, status);
+        Invoice invoice = new Invoice(invoiceId, customerId, new ArrayList<>(sessions), createdAt, status);
         invoicesByCustomer.computeIfAbsent(customerId, k -> new ArrayList<>()).add(invoice);
     }
 
@@ -54,6 +63,12 @@ public class InvoiceManager {
     public String addInvoiceAutoId(String customerId, ChargingSession session, Date createdAt, InvoiceStatus status) {
         String invoiceId = generateNextInvoiceId();
         addInvoice(invoiceId, customerId, session, createdAt, status);
+        return invoiceId;
+    }
+
+    public String addInvoiceAutoId(String customerId, List<ChargingSession> sessions, Date createdAt, InvoiceStatus status) {
+        String invoiceId = generateNextInvoiceId();
+        addInvoice(invoiceId, customerId, sessions, createdAt, status);
         return invoiceId;
     }
 
@@ -94,7 +109,7 @@ public class InvoiceManager {
         double paidInvoiceSum = invoicesByCustomer.getOrDefault(customerId, List.of())
                 .stream()
                 .filter(i -> i.status() == InvoiceStatus.PAID)
-                .mapToDouble(i -> i.session().totalCost())
+                .mapToDouble(Invoice::totalCost)
                 .sum();
 
         return topUpSum - paidInvoiceSum;
@@ -113,8 +128,12 @@ public class InvoiceManager {
     ) {
         var invoices = invoiceManager.readInvoices(customerId);
 
-        // sort by session start time
-        invoices.sort(java.util.Comparator.comparing(i -> i.session().startTime()));
+        // sort by earliest session start time
+        invoices.sort(java.util.Comparator.comparing(i -> i.sessions().stream()
+                .map(ChargingSession::startTime)
+                .filter(Objects::nonNull)
+                .min(Date::compareTo)
+                .orElse(new Date(0))));
 
         if (invoices.isEmpty()) {
             System.out.println("(no invoices)");
@@ -123,42 +142,51 @@ public class InvoiceManager {
 
         int itemNo = 1;
         for (Invoice inv : invoices) {
-            ChargingSession s = inv.session();
-
-            ChargingPoint cp = chargingPointManager.readChargingPoint(s.chargingPointId());
-
-            String chargingPointId = s.chargingPointId();
-            String mode = "UNKNOWN";
-            String locationName = "UNKNOWN";
-
-            if (cp != null) {
-                chargingPointId = cp.id();
-                mode = cp.type().name(); // AC/DC
-
-                Location loc = locationManager.readLocation(cp.locationId());
-                if (loc != null) {
-                    locationName = loc.name();
-                }
-            }
-
-            long durationMin = 0;
-            if (s.startTime() != null && s.endTime() != null) {
-                durationMin = (s.endTime().getTime() - s.startTime().getTime()) / 60000;
-            }
-
             System.out.printf(
                     java.util.Locale.ROOT,
-                    "%d) invoice=%s | location=%s | cp=%s | mode=%s | duration=%d min | energy=%.2f kWh | price=%.2f | status=%s%n",
+                    "%d) invoice=%s | total=%.2f | status=%s%n",
                     itemNo++,
                     inv.id(),
-                    locationName,
-                    chargingPointId,
-                    mode,
-                    durationMin,
-                    s.kWhCharged(),
-                    s.totalCost(),
+                    inv.totalCost(),
                     inv.status()
             );
+
+            int lineNo = 1;
+            for (ChargingSession s : inv.sessions()) {
+                ChargingPoint cp = chargingPointManager.readChargingPoint(s.chargingPointId());
+
+                String chargingPointId = s.chargingPointId();
+                String mode = "UNKNOWN";
+                String locationName = "UNKNOWN";
+
+                if (cp != null) {
+                    chargingPointId = cp.id();
+                    mode = cp.type().name(); // AC/DC
+
+                    Location loc = locationManager.readLocation(cp.locationId());
+                    if (loc != null) {
+                        locationName = loc.name();
+                    }
+                }
+
+                long durationMin = 0;
+                if (s.startTime() != null && s.endTime() != null) {
+                    durationMin = (s.endTime().getTime() - s.startTime().getTime()) / 60000;
+                }
+
+                System.out.printf(
+                        java.util.Locale.ROOT,
+                        "  %d.%d) location=%s | cp=%s | mode=%s | duration=%d min | energy=%.2f kWh | price=%.2f%n",
+                        itemNo - 1,
+                        lineNo++,
+                        locationName,
+                        chargingPointId,
+                        mode,
+                        durationMin,
+                        s.kWhCharged(),
+                        s.totalCost()
+                );
+            }
         }
     }
 

--- a/src/main/java/org/example/Tariff.java
+++ b/src/main/java/org/example/Tariff.java
@@ -9,7 +9,7 @@ public record Tariff(
 ) {
     @Override
     public String toString() {
-        return "Tariff{id='%s', kWhAC=%s, kWhDC=%s, minAC=%s, minDC=%s}"
+        return "Tariff{id='%s', pricePerKwhAC=%s, pricePerKwhDC=%s, parkingPerMinAC=%s, parkingPerMinDC=%s}"
                 .formatted(tariffId, pricePerKwhAC, pricePerKwhDC, pricePerMinuteAC, pricePerMinuteDC);
     }
 }

--- a/src/test/java/org/example/StepDefinitions.java
+++ b/src/test/java/org/example/StepDefinitions.java
@@ -425,25 +425,44 @@ public class StepDefinitions {
             currentCustomerId = identifiedCustomer.id();
         }
 
+        Map<String, List<Map<String, String>>> rowsByInvoice = new java.util.LinkedHashMap<>();
         for (Map<String, String> row : table.asMaps(String.class, String.class)) {
+            rowsByInvoice.computeIfAbsent(row.get("invoiceId"), key -> new java.util.ArrayList<>()).add(row);
+        }
 
-            ChargingSession session = new ChargingSession(
-                    row.get("sessionId"),
-                    currentCustomerId,
-                    row.get("chargingPointId"),
-                    parseIsoDateTime(row.get("startTime")),
-                    parseIsoDateTime(row.get("endTime")),
-                    Double.parseDouble(row.get("kWhCharged")),
-                    Double.parseDouble(row.get("totalCost")),
-                    ChargingSessionStatus.FINISHED
-            );
+        for (Map.Entry<String, List<Map<String, String>>> entry : rowsByInvoice.entrySet()) {
+            String invoiceId = entry.getKey();
+            List<ChargingSession> sessions = new java.util.ArrayList<>();
+            Date createdAt = null;
+            InvoiceStatus status = null;
+
+            for (Map<String, String> row : entry.getValue()) {
+                ChargingSession session = new ChargingSession(
+                        row.get("sessionId"),
+                        currentCustomerId,
+                        row.get("chargingPointId"),
+                        parseIsoDateTime(row.get("startTime")),
+                        parseIsoDateTime(row.get("endTime")),
+                        Double.parseDouble(row.get("kWhCharged")),
+                        Double.parseDouble(row.get("totalCost")),
+                        ChargingSessionStatus.FINISHED
+                );
+                sessions.add(session);
+
+                if (createdAt == null) {
+                    createdAt = parseIsoDateTime(row.get("endTime"));
+                }
+                if (status == null) {
+                    status = InvoiceStatus.valueOf(row.get("status"));
+                }
+            }
 
             invoiceManager.addInvoice(
-                    row.get("invoiceId"),
+                    invoiceId,
                     currentCustomerId,
-                    session,
-                    parseIsoDateTime(row.get("endTime")),
-                    InvoiceStatus.valueOf(row.get("status"))
+                    sessions,
+                    createdAt,
+                    status
             );
         }
     }
@@ -475,9 +494,26 @@ public class StepDefinitions {
                 .orElse(null);
 
         assertNotNull(invoice, "Invoice not found: " + invoiceId);
-        assertEquals(sessionId, invoice.session().id());
-        assertEquals(chargingPointId, invoice.session().chargingPointId());
-        assertEquals(totalCost, invoice.session().totalCost(), 0.0001);
+        ChargingSession session = invoice.sessions().stream()
+                .filter(s -> s.id().equals(sessionId))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(session, "Session not found in invoice: " + sessionId);
+        assertEquals(chargingPointId, session.chargingPointId());
+        assertEquals(totalCost, session.totalCost(), 0.0001);
+    }
+
+    @Then("invoice {string} has {int} sessions")
+    public void invoice_has_sessions(String invoiceId, int expectedSessions) {
+        assertNotNull(lastInvoices);
+
+        Invoice invoice = lastInvoices.stream()
+                .filter(i -> i.id().equals(invoiceId))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(invoice, "Invoice not found: " + invoiceId);
+        assertEquals(expectedSessions, invoice.sessions().size());
     }
 
     // =========================================================
@@ -493,7 +529,13 @@ public class StepDefinitions {
     @When("a customer registers with first name {string} and last name {string}")
     public void a_customer_registers_with_first_name_and_last_name(String firstName, String lastName) {
         assertNotNull(customerManager, "customerManager must be initialized");
-        createdCustomer = customerManager.createCustomer(firstName, lastName);
+        lastError = null;
+        createdCustomer = null;
+        try {
+            createdCustomer = customerManager.createCustomer(firstName, lastName);
+        } catch (Exception e) {
+            lastError = e;
+        }
     }
 
     @Then("the system creates the customer")
@@ -581,6 +623,20 @@ public class StepDefinitions {
         invoiceManager.addTopUp(topUpId, identifiedCustomer.id(), amount, new Date());
     }
 
+    @When("the customer attempts to top up amount {double}")
+    public void the_customer_attempts_to_top_up_amount(double amount) {
+        assertNotNull(invoiceManager, "invoiceManager must be initialized");
+        assertNotNull(identifiedCustomer, "Customer must be identified first");
+
+        lastError = null;
+        try {
+            String topUpId = "T_ERR_" + System.currentTimeMillis();
+            invoiceManager.addTopUp(topUpId, identifiedCustomer.id(), amount, new Date());
+        } catch (Exception e) {
+            lastError = e;
+        }
+    }
+
     @Then("the customer balance is {double}")
     public void the_customer_balance_is(double expected) {
         assertNotNull(invoiceManager, "invoiceManager must be initialized");
@@ -611,8 +667,8 @@ public class StepDefinitions {
 
     private List<ChargingPoint> lastCustomerChargingPoints;
     private ChargingPoint lastCustomerSelectedChargingPoint;
-    private double lastCustomerKwhPerHour;
-    private double lastCustomerPricePerMinute;
+    private double lastCustomerPricePerKwh;
+    private double lastCustomerParkingPerMinute;
 
     // --- helper step: define tariff directly for a location (customer scenarios need tariffs) ---
     @Given("location {string} has tariff")
@@ -688,21 +744,21 @@ public class StepDefinitions {
 
         Tariff t = loc.tariff();
 
-        // NEW meaning: kWhAC/kWhDC = charging speed (kWh per hour), minAC/minDC = price per minute
+        // NEW meaning: kWhAC/kWhDC = price per kWh, minAC/minDC = parking price per minute
         if (lastCustomerSelectedChargingPoint.type() == ChargingType.AC) {
-            lastCustomerKwhPerHour = t.pricePerKwhAC();        // kWh per hour
-            lastCustomerPricePerMinute = t.pricePerMinuteAC(); // €/min
+            lastCustomerPricePerKwh = t.pricePerKwhAC();
+            lastCustomerParkingPerMinute = t.pricePerMinuteAC();
         } else {
-            lastCustomerKwhPerHour = t.pricePerKwhDC();
-            lastCustomerPricePerMinute = t.pricePerMinuteDC();
+            lastCustomerPricePerKwh = t.pricePerKwhDC();
+            lastCustomerParkingPerMinute = t.pricePerMinuteDC();
         }
     }
 
-    @Then("the system shows charging speed kWhPerHour {double} and pricePerMinute {double}")
-    public void the_system_shows_charging_speed_and_price_per_minute(double expectedKwhPerHour, double expectedPricePerMinute) {
+    @Then("the system shows price per kWh {double} and parking per minute {double}")
+    public void the_system_shows_price_per_kwh_and_parking_per_minute(double expectedPricePerKwh, double expectedParkingPerMinute) {
         assertNotNull(lastCustomerSelectedChargingPoint, "No charging point selected");
-        assertEquals(expectedKwhPerHour, lastCustomerKwhPerHour, 0.00001);
-        assertEquals(expectedPricePerMinute, lastCustomerPricePerMinute, 0.00001);
+        assertEquals(expectedPricePerKwh, lastCustomerPricePerKwh, 0.00001);
+        assertEquals(expectedParkingPerMinute, lastCustomerParkingPerMinute, 0.00001);
     }
 
     // =========================================================
@@ -732,6 +788,12 @@ public class StepDefinitions {
         invoiceManager.addTopUp("T_BAL_" + System.currentTimeMillis(), identifiedCustomer.id(), amount, new java.util.Date());
     }
 
+    @Given("the customer has no balance")
+    public void the_customer_has_no_balance() {
+        assertNotNull(identifiedCustomer, "identifiedCustomer must be set first");
+        invoiceManager = new InvoiceManager();
+    }
+
     // -------------------------
 // US-9 start session
 // -------------------------
@@ -757,6 +819,16 @@ public class StepDefinitions {
         assertNotNull(lastStartedSession);
 
         lastSessionId = lastStartedSession.id();
+    }
+
+    @When("the customer attempts to start charging session on charging point {string}")
+    public void the_customer_attempts_to_start_charging_session_on_charging_point(String chargingPointId) {
+        lastError = null;
+        try {
+            the_customer_starts_charging_session_on_charging_point(chargingPointId);
+        } catch (AssertionError | RuntimeException e) {
+            lastError = e;
+        }
     }
 
     @Then("a new charging session is created and is ACTIVE")
@@ -807,15 +879,13 @@ public class StepDefinitions {
 
         Tariff t = loc.tariff();
 
-        // new tariff meaning:
-        // kWhAC/kWhDC = kWh per hour (speed)
-        // minAC/minDC = price per minute
-        double kWhPerHour = (cp.type() == ChargingType.AC) ? t.pricePerKwhAC() : t.pricePerKwhDC();
-        double pricePerMinute = (cp.type() == ChargingType.AC) ? t.pricePerMinuteAC() : t.pricePerMinuteDC();
+        double pricePerKwh = (cp.type() == ChargingType.AC) ? t.pricePerKwhAC() : t.pricePerKwhDC();
+        double parkingPerMinute = (cp.type() == ChargingType.AC) ? t.pricePerMinuteAC() : t.pricePerMinuteDC();
 
+        double powerKw = (cp.type() == ChargingType.AC) ? 11.0 : 50.0;
         double hours = minutes / 60.0;
-        double energy = kWhPerHour * hours;
-        double cost = minutes * pricePerMinute;
+        double energy = powerKw * hours;
+        double cost = energy * pricePerKwh + minutes * parkingPerMinute;
 
         // "simulate" end time after X minutes (still deterministic)
         java.util.Date fakeEnd = new java.util.Date(s.startTime().getTime() + minutes * 60_000L);

--- a/src/test/resources/org/example/CustomerRegistration.feature
+++ b/src/test/resources/org/example/CustomerRegistration.feature
@@ -10,3 +10,8 @@ Feature: Customer EPIC 1 - Customer Registration Management
     Then the system creates the customer
     And the customer id starts with "C"
     And the customer data is first name "Nisa" and last name "Yesillik"
+
+  Scenario: Prevent registration with missing name
+    Given there are no customers
+    When a customer registers with first name "" and last name "Yesillik"
+    Then the system shows an error containing "first name"

--- a/src/test/resources/org/example/Customer_Manage_PrepaidBalance.feature
+++ b/src/test/resources/org/example/Customer_Manage_PrepaidBalance.feature
@@ -4,14 +4,16 @@ Feature: Customer EPIC 2 - Manage Customer Prepaid Balance
   I want to manage my prepaid balance (top up, view invoices, view balance) and identify myself
   so that I can control my charging costs.
 
-  # -------------------------------------------------
-  # US-5 – Customer Identification
-  # -------------------------------------------------
-  Scenario: Customer identifies themselves by first and last name
+  Background:
     Given there are customers
       | firstName | lastName |
       | Nisa      | Yesillik |
       | Max       | Huber    |
+
+  # -------------------------------------------------
+  # US-5 – Customer Identification
+  # -------------------------------------------------
+  Scenario: Customer identifies themselves by first and last name
     When the customer identifies as first name "Nisa" and last name "Yesillik"
     Then the system recognizes the customer
 
@@ -19,22 +21,21 @@ Feature: Customer EPIC 2 - Manage Customer Prepaid Balance
   # US-3 – Top up account before charging session
   # -------------------------------------------------
   Scenario: Customer tops up their prepaid balance
-    Given there are customers
-      | firstName | lastName |
-      | Nisa      | Yesillik |
-    And the customer identifies as first name "Nisa" and last name "Yesillik"
+    Given the customer identifies as first name "Nisa" and last name "Yesillik"
     And the customer has no top-ups yet
     When the customer tops up amount 20.00
     Then the customer balance is 20.00
+
+  Scenario: Customer cannot top up with a negative amount
+    Given the customer identifies as first name "Nisa" and last name "Yesillik"
+    When the customer attempts to top up amount -5.00
+    Then the system shows an error containing "must be > 0"
 
   # -------------------------------------------------
   # US-4 – View all invoices and current balance
   # -------------------------------------------------
   Scenario: Customer views invoices and current balance
-    Given there are customers
-      | firstName | lastName |
-      | Nisa      | Yesillik |
-    And the customer identifies as first name "Nisa" and last name "Yesillik"
+    Given the customer identifies as first name "Nisa" and last name "Yesillik"
     And the customer has top-ups
       | id | amount | dateTime         |
       | T1 | 30.00  | 2026-01-17T09:00 |
@@ -42,7 +43,8 @@ Feature: Customer EPIC 2 - Manage Customer Prepaid Balance
     And the customer has invoices
       | invoiceId | sessionId | chargingPointId | startTime        | endTime          | kWhCharged | totalCost | status |
       | I1        | S1        | CP1             | 2026-01-17T10:00 | 2026-01-17T10:30 | 12.50      | 7.80      | PAID   |
-      | I2        | S2        | CP2             | 2026-01-17T11:00 | 2026-01-17T11:10 | 5.00       | 4.20      | PAID   |
+      | I1        | S2        | CP2             | 2026-01-17T11:00 | 2026-01-17T11:10 | 5.00       | 4.20      | PAID   |
     When the customer requests their invoices and balance
-    Then the system returns 2 invoices
+    Then the system returns 1 invoices
+    And invoice "I1" has 2 sessions
     And the customer balance is 28.00

--- a/src/test/resources/org/example/Customer_StartChargingSession.feature
+++ b/src/test/resources/org/example/Customer_StartChargingSession.feature
@@ -11,7 +11,7 @@ Feature: Customer EPIC 4 - Start Charging Session
       | CP1 | L1         | AC   | AVAILABLE |
     And location "L1" has tariff
       | kWhAC | kWhDC | minAC | minDC |
-      | 20    | 15    | 0.09  | 0.01  |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
     And there are customers
       | firstName | lastName |
       | Nisa      | Yesillik |
@@ -35,5 +35,13 @@ Feature: Customer EPIC 4 - Start Charging Session
     When 30 minutes pass for that session
     And the customer requests charging session information
     Then the session shows duration 30 minutes
-    And the session shows charged energy 10.00 kWh
-    And the session shows total cost 2.70
+    And the session shows charged energy 5.50 kWh
+    And the session shows total cost 3.80
+
+  # ---------------------------
+  # Edge case: insufficient balance
+  # ---------------------------
+  Scenario: Customer cannot start a charging session without balance
+    Given the customer has no balance
+    When the customer attempts to start charging session on charging point "CP1"
+    Then the system shows an error containing "balance"

--- a/src/test/resources/org/example/Customer_ViewNetwork.feature
+++ b/src/test/resources/org/example/Customer_ViewNetwork.feature
@@ -15,10 +15,10 @@ Feature: Customer EPIC 3 - View Network
       | CP4 | L2         | AC   | AVAILABLE    |
     And location "L1" has tariff
       | kWhAC | kWhDC | minAC | minDC |
-      | 20    | 15    | 0.09  | 0.01  |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
     And location "L2" has tariff
       | kWhAC | kWhDC | minAC | minDC |
-      | 18    | 25    | 0.08  | 0.03  |
+      | 0.18  | 0.25  | 0.08  | 0.03  |
 
   # ---------------------------
   # US-6 View all AC/DC charging points
@@ -38,8 +38,16 @@ Feature: Customer EPIC 3 - View Network
   # ---------------------------
   Scenario: Customer views current price for a selected charging point (AC)
     When the customer requests current price for charging point "CP1"
-    Then the system shows charging speed kWhPerHour 20 and pricePerMinute 0.09
+    Then the system shows price per kWh 0.20 and parking per minute 0.09
 
   Scenario: Customer views current price for a selected charging point (DC)
     When the customer requests current price for charging point "CP2"
-    Then the system shows charging speed kWhPerHour 15 and pricePerMinute 0.01
+    Then the system shows price per kWh 0.15 and parking per minute 0.01
+
+  # ---------------------------
+  # Edge case: no charging points
+  # ---------------------------
+  Scenario: Customer views charging points when none exist
+    Given the network is empty
+    When the customer requests all charging points
+    Then the system returns 0 charging points

--- a/src/test/resources/org/example/Manage_Pricing.feature
+++ b/src/test/resources/org/example/Manage_Pricing.feature
@@ -13,25 +13,43 @@ Feature: EPIC 2 - Manage Pricing
   # US-6 Define prices
   # =========================
   Scenario: Define AC and DC prices for a location
-    Given a location exists with id "L1", name "Vienna Center", address "Stephansplatz 1"
     When the operator defines a tariff for location "L1" with:
       | kWhAC | kWhDC | minAC | minDC |
-      | 20    | 15    | 0.09  | 0.01  |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
     Then location "L1" has tariff:
       | kWhAC | kWhDC | minAC | minDC |
-      | 20    | 15    | 0.09  | 0.01  |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
 
   # =========================
   # US-7 Update prices
   # =========================
   Scenario: Update pricing information for a location
-    Given a location exists with id "L1", name "Vienna Center", address "Stephansplatz 1"
     And the operator defines a tariff for location "L1" with:
       | kWhAC | kWhDC | minAC | minDC |
-      | 20    | 15    | 0.09  | 0.01  |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
     When the operator updates the tariff for location "L1" to:
       | kWhAC | kWhDC | minAC | minDC |
-      | 22    | 18    | 0.10  | 0.02  |
+      | 0.22  | 0.18  | 0.10  | 0.02  |
     Then location "L1" has tariff:
       | kWhAC | kWhDC | minAC | minDC |
-      | 22    | 18    | 0.10  | 0.02  |
+      | 0.22  | 0.18  | 0.10  | 0.02  |
+
+  Scenario: Define tariffs for multiple locations
+    When the operator defines a tariff for location "L1" with:
+      | kWhAC | kWhDC | minAC | minDC |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
+    And the operator defines a tariff for location "L2" with:
+      | kWhAC | kWhDC | minAC | minDC |
+      | 0.25  | 0.18  | 0.10  | 0.02  |
+    Then location "L1" has tariff:
+      | kWhAC | kWhDC | minAC | minDC |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
+    And location "L2" has tariff:
+      | kWhAC | kWhDC | minAC | minDC |
+      | 0.25  | 0.18  | 0.10  | 0.02  |
+
+  Scenario: Prevent defining tariffs for an unknown location
+    When the operator defines a tariff for location "L99" with:
+      | kWhAC | kWhDC | minAC | minDC |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
+    Then the system shows an error containing "Location not found"

--- a/src/test/resources/org/example/Network_Monitoring.feature
+++ b/src/test/resources/org/example/Network_Monitoring.feature
@@ -30,15 +30,26 @@ Feature: EPIC 3 - Network Monitoring
       | L2 | Graz East     | Hauptstrasse 5  |
     And the operator defines a tariff for location "L1" with:
       | kWhAC | kWhDC | minAC | minDC |
-      | 20    | 15    | 0.09  | 0.01  |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
     And the operator defines a tariff for location "L2" with:
       | kWhAC | kWhDC | minAC | minDC |
-      | 25    | 18    | 0.10  | 0.02  |
+      | 0.25  | 0.18  | 0.10  | 0.02  |
     When the operator requests current prices for all locations
     Then the system returns current prices for 2 locations
     And location "L1" current price is
       | kWhAC | kWhDC | minAC | minDC |
-      | 20    | 15    | 0.09  | 0.01  |
+      | 0.20  | 0.15  | 0.09  | 0.01  |
     And location "L2" current price is
       | kWhAC | kWhDC | minAC | minDC |
-      | 25    | 18    | 0.10  | 0.02  |
+      | 0.25  | 0.18  | 0.10  | 0.02  |
+
+  # ------------------------------------------------------------
+  # Edge case - no available charging points
+  # ------------------------------------------------------------
+  Scenario: View available charging points when none are available
+    Given the network has charging points
+      | id  | locationId | type | status       |
+      | CP1 | L1         | AC   | OCCUPIED     |
+      | CP2 | L1         | DC   | OUT_OF_ORDER |
+    When the operator requests all available charging points
+    Then the system returns 0 available charging points

--- a/src/test/resources/org/example/TrackSessionsandBilling .feature
+++ b/src/test/resources/org/example/TrackSessionsandBilling .feature
@@ -31,3 +31,11 @@ Feature: EPIC 4 - Track Sessions and Billing
     When the operator requests billing history for that customer
     Then the system returns 2 top-ups and 1 invoices
     And invoice "I1" includes session "S1" on charging point "CP1" with total cost 7.80
+
+  # ------------------------------------------------------------
+  # Edge case - customer without billing history
+  # ------------------------------------------------------------
+  Scenario: view empty billing history for a customer
+    Given a customer exists with id "C2"
+    When the operator requests billing history for that customer
+    Then the system returns 0 top-ups and 0 invoices


### PR DESCRIPTION
### Motivation
- Complete remaining functional requirements for billing and BDD: invoices should represent a single invoice with multiple invoice lines (sessions) and the pricing model should reflect `price per kWh` + `parking per minute` rather than the previous ambiguous semantics. 
- Improve invoice/CLI output so customers/operators see a clear invoice with line-item breakdowns (energy vs. parking). 
- Expand BDD feature coverage to include backgrounds, multi-session invoices, and error/edge cases (invalid top-ups, missing names, no charging points, insufficient balance). 

### Description
- Model change: `Invoice` now holds `List<ChargingSession> sessions` and computes `totalCost()` by summing session costs, and `InvoiceManager` supports creating invoices with multiple sessions and auto-generated invoice IDs. 
- Pricing/charging calculation: `Tariff` semantics updated to `pricePerKwhAC/DC` and `parkingPerMinAC/DC`, `ChargingSessionManager.calculateForSession` now computes kWh from a fixed power (`11.0` kW for AC, `50.0` kW for DC) and cost = `energy * pricePerKwh + minutes * parkingPerMin`. 
- CLI and invoice output: `ElectricChargingPointNetwork` prints invoices as one invoice with numbered session lines and shows energy/energy-cost/parking-cost breakdowns; live session estimation uses the centralized calculation. 
- Validation and tests: `CustomerManager.createCustomer` validates non-empty names; `StepDefinitions` updated to support grouped invoice rows, new negative/edge-case steps, and to expect the new price semantics; multiple `.feature` files updated with backgrounds, multi-location pricing scenarios and error cases. 

